### PR TITLE
FaxOptions and documentation updates

### DIFF
--- a/Docs/README-csharp-v2.md
+++ b/Docs/README-csharp-v2.md
@@ -65,10 +65,34 @@ batching FaxOptions would look like:
         File = pdf2,
         BatchDelaySeconds = 30
     };
-    phaxio.SendFax("8088675309", faxRequest1);
-    phaxio.SendFax("8088675309", faxRequest2);
+    phaxio.SendFax(faxRequest1);
+    phaxio.SendFax(faxRequest2);
 
 The machine at 808-867-5309 will see pdf1 and pdf2 as one long fax.
+
+### Using content URLs
+
+You can also specify a URL to pull the content of your fax from:
+
+    var faxRequest = new FaxRequest
+    {
+        ToNumber = "8088675309",
+        ContentUrl = "http://example.com/invoice/1234"
+    };
+    phaxio.SendFax(faxRequest);
+
+If you have multiple URLs to specify, you can set ContentUrls to an IEnumerable<string> to pass multiple URLs
+
+    var faxRequest = new FaxRequest
+    {
+        ToNumber = "8088675309",
+        ContentUrls = new List<string>
+        {
+            "http://example.com/invoice/1234",
+            "http://example.com/invoice/5678"
+        }
+    };
+    phaxio.SendFax(faxRequest);
 
 ### Querying sent faxes
 

--- a/Docs/README-vb-v2.md
+++ b/Docs/README-vb-v2.md
@@ -69,6 +69,30 @@ batching FaxOptions would look like:
 
 The machine at 808-867-5309 will see pdf1 and pdf2 as one long fax.
 
+### Using content URLs
+
+You can also specify a URL to pull the content of your fax from:
+
+    Dim faxRequest = New FaxRequest With
+    {
+        .ToNumber = "8088675309",
+        .ContentUrl = "http://example.com/invoice/1234"
+    }
+    phaxio.SendFax(faxRequest)
+
+If you have multiple URLs to specify, you use an IEnumerable(Of string) to pass multiple URLs
+
+    Dim faxRequest = New FaxRequest With
+    {
+        .ToNumber = "8088675309",
+        .ContentUrls = New List(Of string) From
+        {
+            "http://example.com/invoice/1234",
+            "http://example.com/invoice/5678"
+        }
+    }
+    phaxio.SendFax(faxRequest)
+
 ### Querying sent faxes
 
 To see your sent faxes after you've sent it, call ListFaxes:

--- a/Phaxio.Tests/UnitTests/FaxTests.cs
+++ b/Phaxio.Tests/UnitTests/FaxTests.cs
@@ -513,5 +513,34 @@ namespace Phaxio.Tests
 
             Assert.IsTrue(result.Success);
         }
+
+        [Test]
+        public void UnitTests_Fax_Send_OnlySpecifiedOptions()
+        {
+            var testToNumber = "8088675309";
+            var testOptions = new FaxOptions
+            {
+                StringData = "somedata",
+                StringDataType = "html"
+            };
+
+            Action<IRestRequest> requestAsserts = req =>
+            {
+                var parameters = ParametersHelper.ToDictionary(req.Parameters);
+
+                Assert.AreEqual(testToNumber, parameters["to[]"]);
+                Assert.False(parameters.ContainsKey("batch"));
+                Assert.False(parameters.ContainsKey("batch_delay"));
+                Assert.False(parameters.ContainsKey("batch_collision_avoidance"));
+                Assert.False(parameters.ContainsKey("cancel_timeout"));
+            };
+
+            var clientBuilder = new IRestClientBuilder { Op = "send", RequestAsserts = requestAsserts };
+            var phaxio = new PhaxioClient(IRestClientBuilder.TEST_KEY, IRestClientBuilder.TEST_SECRET, clientBuilder.Build());
+
+            var testFile = BinaryFixtures.getTestPdfFile();
+
+            var faxId = phaxio.SendFax(testToNumber, testFile, testOptions);
+        }
     }
 }

--- a/Phaxio/Entities/FaxOptions.cs
+++ b/Phaxio/Entities/FaxOptions.cs
@@ -32,19 +32,19 @@ namespace Phaxio.Entities
         /// If present and true, fax will be sent in batching mode. Requires BatchDelaySeconds to be specified. See batching for more info.
         /// </summary>
         [SerializeAsAttribute("batch")]
-        public bool IsBatch { get; set; }
+        public bool? IsBatch { get; set; }
         
         /// <summary>
         /// The amount of time, in seconds, before the batch is fired. Must be specified if IsBatch=true. Maximum delay is 3600 (1 hour).
         /// </summary>
         [SerializeAsAttribute("batch_delay")]
-        public int BatchDelaySeconds { get; set; }
+        public int? BatchDelaySeconds { get; set; }
         
         /// <summary>
         /// If true when batch=true, fax will be blocked until the receiving machine is no longer busy. See batching for more info.
         /// </summary>
         [SerializeAsAttribute("batch_collision_avoidance")]
-        public bool AvoidBatchCollision { get; set; }
+        public bool? AvoidBatchCollision { get; set; }
         
         /// <summary>
         /// You can specify a callback url that will override the one you have defined globally for your account.
@@ -57,7 +57,7 @@ namespace Phaxio.Entities
         /// Additionally, for faxes with a BatchDelaySeconds, the CancelTimeoutAfter must be at least 3 minutes after the batch_delay.
         /// </summary>
         [SerializeAsAttribute("cancel_timeout")]
-        public int CancelTimeoutAfter { get; set; }
+        public int? CancelTimeoutAfter { get; set; }
         
         /// <summary>
         /// Tags for your fax. You may specify a maximum of 10.


### PR DESCRIPTION
I updated FaxOptions to make all parameters optional in the V1 PhaxioClient. Included in this update is documentation and examples for using ContentUrls to send faxes.