### PR TITLE
Use content type of an HTTP response to get error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 ## Project-specific ignores
 keys.ini
+tools/
+.nuget/
+
+# macOS
+.DS_Store
 
 # General .NET/Visual Studio ignores
 ## Ignore Visual Studio temporary files, build results, and

--- a/Phaxio.Tests/Helpers/RestClientBuilder.cs
+++ b/Phaxio.Tests/Helpers/RestClientBuilder.cs
@@ -41,6 +41,13 @@ namespace Phaxio.Tests.Helpers
             return this;
         }
 
+        public RestClientBuilder AsText()
+        {
+            contentType = "text/plain";
+
+            return this;
+        }
+
         public RestClientBuilder AsPng()
         {
             contentType = "image/png";

--- a/Phaxio.Tests/README.md
+++ b/Phaxio.Tests/README.md
@@ -1,5 +1,9 @@
 ﻿# Testing
 
+## Testing outside Visual Studio
+
+Run ./test.sh
+
 ## Integration tests
 
 Integration tests must be run explicitly. To run them, you must first place your API keys in an a file called "keys.ini". (This file will not be checked into Git, as it is ignored). See the sample file keys.ini.sample for an example.

--- a/Phaxio.Tests/UnitTests/FaxTests.cs
+++ b/Phaxio.Tests/UnitTests/FaxTests.cs
@@ -137,7 +137,6 @@ namespace Phaxio.Tests.UnitTests.V2
 
             var faxInfo = phaxio.Fax.Retrieve(123456);
 
-            DateTime createdAt = Convert.ToDateTime("2015-09-02T11:28:02.000-05:00");
             DateTime completedAt = Convert.ToDateTime("2015-09-02T11:28:54.000-05:00");
 
             Assert.AreEqual(123456, faxInfo.Id, "");

--- a/Phaxio.Tests/UnitTests/PhaxioClientTests.cs
+++ b/Phaxio.Tests/UnitTests/PhaxioClientTests.cs
@@ -10,6 +10,27 @@ namespace Phaxio.Tests.UnitTests.V2
     public class PhaxioClientTests
     {
         [Test]
+        public void UnitTests_V2_NonJsonErrorHandled()
+        {
+            var requestAsserts = new RequestAsserts()
+                .Auth()
+                .Get()
+                .Resource("account/status")
+                .Build();
+
+            var restClient = new RestClientBuilder()
+                .WithRequestAsserts(requestAsserts)
+                .AsText()
+                .Content("There was an error")
+                .InternalServerError()
+                .Build<Response<AccountStatus>>();
+
+            var phaxio = new PhaxioClient(RestClientBuilder.TEST_KEY, RestClientBuilder.TEST_SECRET, restClient);
+
+            Assert.Throws(typeof(ServiceException), () => Console.Write(phaxio.Account.Status.Balance));
+        }
+
+        [Test]
         public void UnitTests_V2_RateLimitException()
         {
             var requestAsserts = new RequestAsserts()

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+MONO_EXE="mono"
+NUGET_EXE=".nuget/nuget.exe"
+NUGET_URL="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+NUNIT_RUNNER_EXE="./tools/NUnit.ConsoleRunner.3.6.1/tools/nunit3-console.exe"
+
+# Make sure mono is installed
+if [ ! hash $MONO_EXE 2>/dev/null ]; then
+    echo "Could not find mono. Exiting" >&2
+    exit 1
+fi
+
+# Install Nuget if it isn't present
+if [ ! -d "$DIRECTORY" ]; then
+    mkdir -p .nuget
+fi
+
+if [ ! hash $NUGET_EXE 2>/dev/null ]; then
+    if hash curl 2>/dev/null; then
+        curl -o $NUGET_EXE $NUGET_URL
+    elif hash curl 2>/dev/null; then
+        wget -O $NUGET_EXE $NUGET_URL
+    else
+        echo "Could not find curl or wget. Exiting" >&2
+        exit 1
+    fi
+fi
+
+# Restore the nuget packages
+mono .nuget/nuget.exe restore phaxio-dotnet.sln
+
+# Install the test runner if it's not present
+if [ ! -f $NUNIT_RUNNER_EXE ]; then
+    mono .nuget/nuget.exe install NUnit.Runners -Version 3.6.1 -OutputDirectory tools
+fi
+
+# Build the project
+xbuild /p:Configuration=Release phaxio-dotnet.sln /p:TargetFrameworkVersion="v4.5"
+
+# Run the tests
+mono $NUNIT_RUNNER_EXE ./Phaxio.Tests/bin/Release/Phaxio.Tests.dll


### PR DESCRIPTION
This change has the Phaxio client check the content type before retrieving the error message.