### PR TITLE
Adding byteArray and fileName parameters to FaxRepository.Create

### DIFF
--- a/Phaxio.Tests/UnitTests/FaxTests.cs
+++ b/Phaxio.Tests/UnitTests/FaxTests.cs
@@ -68,6 +68,77 @@ namespace Phaxio.Tests.UnitTests.V2
         }
 
         [Test]
+        public void UnitTests_V2_Fax_Create_With_Byte_Arrays()
+        {
+            var testPdfBytes = BinaryFixtures.GetTestPdf();
+            var testPdfName = "FileName";
+
+            Action<IRestRequest> parameterAsserts = req =>
+            {
+                Assert.AreEqual(1, req.Files.Count);
+                Assert.AreEqual(testPdfName, req.Files.First().FileName);
+                Assert.AreEqual(testPdfBytes, req.Files.First().Bytes);
+            };
+
+            var requestAsserts = new RequestAsserts()
+                .Post()
+                .Custom(parameterAsserts)
+                .Resource("faxes")
+                .Build();
+
+            var restClient = new RestClientBuilder()
+                .WithRequestAsserts(requestAsserts)
+                .AsJson()
+                .Content(JsonResponseFixtures.FromFile("V2/fax_send"))
+                .Ok()
+                .Build<Response<Fax>>();
+
+            var phaxio = new PhaxioClient(RestClientBuilder.TEST_KEY, RestClientBuilder.TEST_SECRET, restClient);
+
+            var fax = phaxio.Fax.Create(to: "123",
+                byteArrays: new byte[][] { testPdfBytes },
+                fileNames: new string[] { testPdfName });
+        }
+
+        [Test]
+        public void UnitTests_V2_Fax_Create_With_Byte_Arrays_No_File_Names()
+        {
+            var testPdfBytes = BinaryFixtures.GetTestPdf();
+
+            var restClient = new RestClientBuilder()
+                .AsJson()
+                .Content(JsonResponseFixtures.FromFile("V2/fax_send"))
+                .Ok()
+                .Build<Response<Fax>>();
+
+            var phaxio = new PhaxioClient(RestClientBuilder.TEST_KEY, RestClientBuilder.TEST_SECRET, restClient);
+
+            Assert.Throws<ArgumentException>(
+                () => { phaxio.Fax.Create(to: "123", byteArrays: new byte[][] { testPdfBytes }); });
+        }
+
+        [Test]
+        public void UnitTests_V2_Fax_Create_With_Byte_Arrays_Too_Many_File_Names()
+        {
+            var testPdfBytes = BinaryFixtures.GetTestPdf();
+            var testPdfName = "FileName";
+
+            var restClient = new RestClientBuilder()
+                .AsJson()
+                .Content(JsonResponseFixtures.FromFile("V2/fax_send"))
+                .Ok()
+                .Build<Response<Fax>>();
+
+            var phaxio = new PhaxioClient(RestClientBuilder.TEST_KEY, RestClientBuilder.TEST_SECRET, restClient);
+
+            Assert.Throws<ArgumentException>(
+                () => { phaxio.Fax.Create(to: "123",
+                byteArrays: new byte[][] { testPdfBytes },
+                fileNames: new string[] { testPdfName, testPdfName });
+            });
+        }
+
+        [Test]
         public void UnitTests_V2_Fax_Cancel()
         {
             var requestAsserts = new RequestAsserts()


### PR DESCRIPTION
I chose to implement this as additional optional parameters since that's what we did with the other ways to get files on the fax and it's the way that will result in the fewest duplicated lines of code.

I included some extra checks to help developers since both parameters need to be set.

Closes #13