### PR TITLE
Update library to use Phaxio API to use v2.1

### DIFF
--- a/Phaxio.Examples.ReceiveCallback/Controllers/FaxController.cs
+++ b/Phaxio.Examples.ReceiveCallback/Controllers/FaxController.cs
@@ -52,7 +52,9 @@ namespace Phaxio.Examples.ReceiveCallback.Controllers
 
                     // Here we get a new Fax object from the key/values
                     // that Phaxio passed us
-                    var receipt = getFaxFromFormData(provider.FormData);
+                    var receipt = new FaxReceipt() {
+                        Fax = JsonConvert.DeserializeObject(provider.FormData["fax"])
+                    };
 
                     // Here we'll get the name of the file so we can
                     // reference it later
@@ -72,20 +74,6 @@ namespace Phaxio.Examples.ReceiveCallback.Controllers
             );
 
             return task;
-        }
-
-        private FaxReceipt getFaxFromFormData(NameValueCollection formData)
-        {
-            return new FaxReceipt
-            {
-                Direction = formData["direction"],
-
-                // The "fax" field is a JSON document, so we'll let
-                // Json.NET make a dynamic object we can use later
-                Fax = JsonConvert.DeserializeObject(formData["fax"]),
-                IsTest = formData["is_test"] == "true" ? true : false,
-                Success = formData["success"] == "true" ? true : false
-            };
         }
     }
 }

--- a/Phaxio.Examples.ReceiveCallback/Models/FaxReceipt.cs
+++ b/Phaxio.Examples.ReceiveCallback/Models/FaxReceipt.cs
@@ -2,10 +2,7 @@
 {
     public class FaxReceipt
     {
-        public string Direction { get; set; }
         public dynamic Fax { get; set; }
-        public bool IsTest { get; set; }
-        public bool Success { get; set; }
         public string Key { get; set; }
     }
 }

--- a/Phaxio.Tests/Fixtures/Json/V2/fax_info.json
+++ b/Phaxio.Tests/Fixtures/Json/V2/fax_info.json
@@ -4,6 +4,20 @@
     "data":{
         "id":123456,
         "direction":"sent",
+        "caller_name": "Alice",
+        "barcodes": [{
+            "type": "barcode-type-1",
+            "page": 1,
+            "value" : "barcode-value-1",
+            "identifier": "phax-code-id-1",
+            "metadata": "phax-code-metadata-1"
+        },{
+            "type": "barcode-type-2",
+            "page": 1,
+            "value" : "barcode-value-2",
+            "identifier": "phax-code-id-2",
+            "metadata": "phax-code-metadata-2"
+        }],
         "num_pages":3,
         "status":"success",
         "is_test":true,

--- a/Phaxio.Tests/Fixtures/Json/V2/fax_list.json
+++ b/Phaxio.Tests/Fixtures/Json/V2/fax_list.json
@@ -4,6 +4,20 @@
     "data":[
         {
             "id":123456,
+            "caller_name": "Alice",
+            "barcodes": [{
+                "type": "barcode-type-1",
+                "page": 1,
+                "value" : "barcode-value-1",
+                "identifier": "phax-code-id-1",
+                "metadata": "phax-code-metadata-1"
+            },{
+                "type": "barcode-type-2",
+                "page": 1,
+                "value" : "barcode-value-2",
+                "identifier": "phax-code-id-2",
+                "metadata": "phax-code-metadata-2"
+            }],
             "direction":"sent",
             "num_pages":1,
             "status":"success",
@@ -32,6 +46,14 @@
         },
         {
             "id":123455,
+            "caller_name": "Bob",
+            "barcodes": [{
+                "type": "barcode-type",
+                "page": 1,
+                "value" : "barcode-value",
+                "identifier": "phax-code-id",
+                "metadata": "phax-code-metadata"
+            }],
             "direction":"sent",
             "num_pages":1,
             "status":"success",
@@ -60,6 +82,8 @@
         },
         {
             "id":123454,
+            "caller_name": "Cathy",
+            "barcodes": [],
             "direction":"sent",
             "num_pages":1,
             "status":"success",

--- a/Phaxio.Tests/Helpers/RequestAsserts.cs
+++ b/Phaxio.Tests/Helpers/RequestAsserts.cs
@@ -24,10 +24,9 @@ namespace Phaxio.Tests.Helpers
         {
             asserts.Enqueue(request =>
             {
-                var parameters = ParametersHelper.ToDictionary(request.Parameters);
-
-                Assert.AreEqual((string)parameters[PhaxioConstants.KEY_NAME], TEST_KEY);
-                Assert.AreEqual((string)parameters[PhaxioConstants.SECRET_NAME], TEST_SECRET);
+                Assert.NotNull(request.Authorization, "Authorization was null");
+                Assert.AreEqual(request.Authorization.Username, TEST_KEY, "Key was incorrect");
+                Assert.AreEqual(request.Authorization.Password, TEST_SECRET, "Secret was incorrect");
             });
 
             return this;

--- a/Phaxio.Tests/UnitTests/FaxTests.cs
+++ b/Phaxio.Tests/UnitTests/FaxTests.cs
@@ -211,6 +211,17 @@ namespace Phaxio.Tests.UnitTests.V2
             DateTime completedAt = Convert.ToDateTime("2015-09-02T11:28:54.000-05:00");
 
             Assert.AreEqual(123456, faxInfo.Id, "");
+            Assert.AreEqual("Alice", faxInfo.CallerName, "");
+            Assert.AreEqual(2, faxInfo.Barcodes.Count(), "");
+
+            var barcode = faxInfo.Barcodes.First();
+
+            Assert.AreEqual("barcode-type-1", barcode.Type, "");
+            Assert.AreEqual(1, barcode.Page, "");
+            Assert.AreEqual("barcode-value-1", barcode.Value, "");
+            Assert.AreEqual("phax-code-id-1", barcode.Identifier, "");
+            Assert.AreEqual("phax-code-metadata-1", barcode.Metadata, "");
+
             Assert.AreEqual("sent", faxInfo.Direction, "");
             Assert.AreEqual(3, faxInfo.NumPages, "");
             Assert.AreEqual("success", faxInfo.Status, "");

--- a/Phaxio/Clients/Internal/BasePhaxioClient.cs
+++ b/Phaxio/Clients/Internal/BasePhaxioClient.cs
@@ -17,7 +17,6 @@ namespace Phaxio.Clients.Internal
         public BasePhaxioClient(string key, string secret)
             : this(key, secret, new RestClient())
         {
-
         }
 
         public BasePhaxioClient(string key, string secret, IRestClient restClient)
@@ -64,8 +63,7 @@ namespace Phaxio.Clients.Internal
 
             if (auth)
             {
-                request.AddParameter(PhaxioConstants.KEY_NAME, key);
-                request.AddParameter(PhaxioConstants.SECRET_NAME, secret);
+                request.Authorization = new BasicAuthorization() { Username = key, Password = secret };
             }
 
             // Run any custom modifications

--- a/Phaxio/Clients/PhaxioClient.cs
+++ b/Phaxio/Clients/PhaxioClient.cs
@@ -12,7 +12,7 @@ namespace Phaxio
 {
     public class PhaxioClient : BasePhaxioClient
     {
-        private const string phaxioApiEndpoint = "https://api.phaxio.com/v2/";
+        private const string phaxioApiEndpoint = "https://api.phaxio.com/v2.1/";
 
         public PhaxioClient(string key, string secret)
             : this(key, secret, new RestClient())

--- a/Phaxio/Entities/Barcode.cs
+++ b/Phaxio/Entities/Barcode.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Phaxio.Entities
+{
+    public class Barcode
+    {
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+
+        [JsonProperty(PropertyName = "page")]
+        public int Page { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
+
+        [JsonProperty(PropertyName = "identifier")]
+        public string Identifier { get; set; }
+
+        [JsonProperty(PropertyName = "metadata")]
+        public string Metadata { get; set; }
+    }
+}

--- a/Phaxio/Phaxio.csproj
+++ b/Phaxio/Phaxio.csproj
@@ -21,7 +21,7 @@
     <PackageProjectUrl>https://github.com/phaxio/phaxio-dotnet</PackageProjectUrl>
     <Copyright>Copyright 2017-2018 Phaxio</Copyright>
     <PackageTags>Phaxio Fax Faxing</PackageTags>
-    <VersionPrefix>2.3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>2.4.0.0-alpha</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Phaxio/Resources/V2/Fax.cs
+++ b/Phaxio/Resources/V2/Fax.cs
@@ -34,6 +34,12 @@ namespace Phaxio.Resources.V2
         [JsonProperty(PropertyName = "id")]
         public int Id { get; set; }
 
+        [JsonProperty(PropertyName = "barcodes")]
+        public IEnumerable<Barcode> Barcodes { get; set; }
+
+        [JsonProperty(PropertyName = "caller_name")]
+        public string CallerName { get; set; }
+
         [JsonProperty(PropertyName = "direction")]
         public string Direction { get; set; }
 

--- a/Phaxio/ThinRestClient/Entities/BasicAuthorization.cs
+++ b/Phaxio/ThinRestClient/Entities/BasicAuthorization.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net.Http.Headers;
+
+namespace Phaxio.ThinRestClient
+{
+    public class BasicAuthorization
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+
+        public AuthenticationHeaderValue ToHeader ()
+        {
+            var authString = string.Format("{0}:{1}", Username, Password);
+            var authBytes = System.Text.ASCIIEncoding.ASCII.GetBytes(authString);
+            return new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+        }
+    }
+}

--- a/Phaxio/ThinRestClient/Entities/Interfaces/IRestRequest.cs
+++ b/Phaxio/ThinRestClient/Entities/Interfaces/IRestRequest.cs
@@ -8,6 +8,7 @@ namespace Phaxio.ThinRestClient
     {
         Method Method { get; set; }
         string Resource { get; set; }
+        BasicAuthorization Authorization { get; set; }
         List<Parameter> Parameters { get; set; }
         List<FileParameter> Files { get; set; }
         IRestRequest AddParameter(string name, object value);

--- a/Phaxio/ThinRestClient/Entities/RestRequest.cs
+++ b/Phaxio/ThinRestClient/Entities/RestRequest.cs
@@ -12,6 +12,8 @@ namespace Phaxio.ThinRestClient
 
         public string Resource { get; set; }
 
+        public BasicAuthorization Authorization { get; set; }
+
         public List<Parameter> Parameters { get; set; }
 
         public Action<Stream> ResponseWriter { get; set; }

--- a/Phaxio/ThinRestClient/RestClient.cs
+++ b/Phaxio/ThinRestClient/RestClient.cs
@@ -36,6 +36,11 @@ namespace Phaxio.ThinRestClient
 
             client.BaseAddress = BaseUrl;
             
+            if (request.Authorization != null)
+            {
+                client.DefaultRequestHeaders.Authorization = request.Authorization.ToHeader();
+            }
+            
             HttpResponseMessage response;
 
             if (request.Method == Method.GET)


### PR DESCRIPTION
Phaxio has released a new API, so we need to update this client library to support those changes. There are three major updates: a new endpoint, removing parameters from the fax callback, and moving to HTTP Basic Authorization.

1) We're going to use a new endpoint for the library (a different version string), which was just changing a string in the `PhaxioClient` class.

2) The callback example project needed to remove `success`, `is_test`, and `direction` from the expected parameters.

3) We needed to move to HTTP Basic Authorization. I added a `BasicAuthorization` object that contained & handled this change, and then updated `IRestRequest` and `RestRequest` to have a field called Authorization that's a `BasicAuthorization` object. The `RestClient` now checks to see if the `IRestRequest` has this field and if so, sets the `HttpClient`'s `DefaultRequestHeaders.Authorization`. Finally, the `BasePhaxioClient` object now adds this object to the IRestRequest instead of setting the key and secret as request parameters.

Finally, `Barcodes` (an array of `int`s) and `CallerName` (a `string`) were added the `Fax` object.

Closes #23 