### PR TITLE
Fix 500 errors with sample callback project

### DIFF
--- a/Phaxio.Examples.ReceiveCallback/Controllers/FaxController.cs
+++ b/Phaxio.Examples.ReceiveCallback/Controllers/FaxController.cs
@@ -25,7 +25,7 @@ namespace Phaxio.Examples.ReceiveCallback.Controllers
             return result;
         }
 
-        public Task<HttpResponseMessage> Post()
+        public async Task<HttpResponseMessage> Post()
         {
             // Check to make sure we're getting the expected format
             // Phaxio will send the callback as a multipart
@@ -41,39 +41,31 @@ namespace Phaxio.Examples.ReceiveCallback.Controllers
             var provider = new MultipartFormDataStreamProvider(root);
 
             // Now we're going to request that the provider process
-            // the request and when it's finished, call back the
-            // lambda below
-            var task = request.Content.ReadAsMultipartAsync(provider).
-                ContinueWith<HttpResponseMessage>(o =>
-                {
-                    // Right here, the provider has read all the data
-                    // We get the file that Phaxio sent us
-                    var file = provider.FileData.First();
+            // the request and when it's finished, proceed to processing
+            await request.Content.ReadAsMultipartAsync(provider);
 
-                    // Here we get a new Fax object from the key/values
-                    // that Phaxio passed us
-                    var receipt = new FaxReceipt() {
-                        Fax = JsonConvert.DeserializeObject(provider.FormData["fax"])
-                    };
+            // Here we get a new Fax object from the key/values
+            // that Phaxio passed us
+            var receipt = new FaxReceipt()
+            {
+                Fax = JsonConvert.DeserializeObject(provider.FormData["fax"])
+            };
 
-                    // Here we'll get the name of the file so we can
-                    // reference it later
-                    receipt.Key = file.LocalFileName;
+            // Here we'll get the name of the file so we can
+            // reference it later
+            var file = provider.FileData.First();
+            receipt.Key = file.LocalFileName;
 
-                    // We're storing the fax in a memory cache
-                    ObjectCache cache = MemoryCache.Default;
-                    var faxList = cache["Callbacks"] as List<FaxReceipt>;
-                    faxList.Add(receipt);
+            // We're storing the fax in a memory cache
+            ObjectCache cache = MemoryCache.Default;
+            var faxList = cache["Callbacks"] as List<FaxReceipt>;
+            faxList.Add(receipt);
 
-                    // Respond to Phaxio's servers
-                    return new HttpResponseMessage()
-                    {
-                        Content = new StringContent("Callback received.")
-                    };
-                }
-            );
-
-            return task;
+            // Respond to Phaxio's servers
+            return new HttpResponseMessage()
+            {
+                Content = new StringContent("Callback received.")
+            };
         }
     }
 }

--- a/Phaxio.Examples.ReceiveCallback/Controllers/TriggerController.cs
+++ b/Phaxio.Examples.ReceiveCallback/Controllers/TriggerController.cs
@@ -1,20 +1,28 @@
 ﻿using System.IO;
 using System.Web.Hosting;
-using System.Web.Http;
+using System.Web.Mvc;
 
 namespace Phaxio.Examples.ReceiveCallback.Controllers
 {
-    public class TriggerController : ApiController
+    public class TriggerController : Controller
     {
-        public bool Get(string key, string secret)
+        [HttpPost]
+        public ActionResult Index()
         {
+            string key = Request.Form["key"];
+            string secret = Request.Form["secret"];
             var phaxio = new PhaxioClient(key, secret);
 
             var filepath = HostingEnvironment.MapPath("~/App_Data/test.pdf");
 
-            phaxio.Fax.TestRecieveCallback(new FileInfo(filepath));
+            var result = phaxio.Fax.TestRecieveCallback(new FileInfo(filepath));
 
-            return true;
+            if (!result.Success)
+            {
+                return Content("Trigger did not work, unfortunately: " + result.Message);
+            }
+
+            return RedirectToAction(nameof(HomeController.Index), "Home");
         }
     }
 }

--- a/Phaxio.Examples.ReceiveCallback/Models/FaxReceipt.cs
+++ b/Phaxio.Examples.ReceiveCallback/Models/FaxReceipt.cs
@@ -1,4 +1,6 @@
-﻿namespace Phaxio.Examples.ReceiveCallback.Models
+﻿using System.Collections.Generic;
+
+namespace Phaxio.Examples.ReceiveCallback.Models
 {
     public class FaxReceipt
     {

--- a/Phaxio.Examples.ReceiveCallback/Views/Home/Index.cshtml
+++ b/Phaxio.Examples.ReceiveCallback/Views/Home/Index.cshtml
@@ -6,7 +6,7 @@
 
 <h2>Recieved callbacks</h2>
 
-<form action="~/api/trigger" method="get">
+<form action="~/trigger" method="post">
     <p>Key: <input type="text" name="key" /></p>
     <p>Secret: <input type="text" name="secret" /></p>
     <p><button>Trigger</button></p>
@@ -18,13 +18,13 @@
         <tr><th>Direction</th><th>Status</th><th>IsTest?</th><th>Fax</th><th>File</th></tr>
         @foreach (var receipt in Model)
         {
-            <tr>
-                <td>@receipt.Fax.Direction</td>
-                <td>@receipt.Fax.Status</td>
-                <td>@receipt.Fax.IsTest</td>
-                <td>@receipt.Fax</td>
-                <td><a href="~/api/fax?key=@receipt.Key">PDF</a></td>
-            </tr>
+        <tr>
+            <td>@receipt.Fax["direction"]</td>
+            <td>@receipt.Fax["status"]</td>
+            <td>@receipt.Fax["is_test"]</td>
+            <td>@receipt.Fax</td>
+            <td><a href="~/api/fax?key=@receipt.Key">PDF</a></td>
+        </tr>
         }
     </table>
 }
@@ -46,6 +46,6 @@ else
     <li>Follow <a href="http://irwinj.blogspot.com/2012/06/using-localtunnel-to-allow-external.html">this tutorial</a> to get IISExpress to allow the proxy</li>
     <li>Run this command: lt --port @Request.Url.Port</li>
     <li>This creates an Internet-accessible address to will proxy requests to your computer</li>
-    <li>Go to your Phaxio control panel and put this as your default callback: proxy + /api/fax/</li>
-    <li>Trigger callback</li>
+    <li>Go to your Phaxio control panel and put this as your default callback: proxy + /api/fax/ (make sure your Webhook version is on 2.1)</li>
+    <li>Trigger callback & refresh this page in a few seconds if you don't see your callback</li>
 </ol>


### PR DESCRIPTION
This project needed several updates to be able to run without giving an error. This modifies the Fax controller (which will receive the Webhook) to actually get the callback form data, which it was not getting before. This was done by using async/await vs. using the ContinueWith method on Task.

The trigger controller was changed to MVC vs. WebAPI since it was being used for a regular HTML form. This allowed us to just redirect vs. showing an XML page.

I also updated the index to have a few more instructions.